### PR TITLE
KAB-889: fix the fully qualified names of the Keboola tables

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "0.1.0"
+version = "0.1.1"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dev = [
     "pytest",
     "pytest-asyncio",
     "pytest-cov",
+    "pytest-mock",
     "black",
     "isort",
     "mypy",

--- a/src/keboola_mcp_server/server.py
+++ b/src/keboola_mcp_server/server.py
@@ -204,8 +204,8 @@ def create_server(config: Optional[Config] = None) -> FastMCP:
         assert isinstance(client, KeboolaClient)
         tables = cast(List[Dict[str, Any]], client.storage_client.buckets.list_tables(bucket_id))
         return "\n".join(
-            f"Table: {table['id']}\n"
-            f"Name: {table.get('name', 'N/A')}\n"
+            f"Table ID: {table['id']}\n"
+            f"Table Name: {table.get('name', 'N/A')}\n"
             f"Rows: {table.get('rowsCount', 'N/A')}\n"
             f"Size: {table.get('dataSizeBytes', 'N/A')} bytes\n"
             f"Columns: {', '.join(table.get('columns', []))}\n"

--- a/src/keboola_mcp_server/server.py
+++ b/src/keboola_mcp_server/server.py
@@ -1,22 +1,20 @@
 """MCP server implementation for Keboola Connection."""
 
-import csv
 import logging
-from io import StringIO
 from typing import Any, cast, Dict, List, Optional, TypedDict
 
-import snowflake.connector
 from mcp.server.fastmcp import Context, FastMCP
 
+from keboola_mcp_server import sql_tools
+from keboola_mcp_server.client import KeboolaClient
+from keboola_mcp_server.config import Config
+from keboola_mcp_server.database import ConnectionManager, DatabasePathManager
 from keboola_mcp_server.mcp import (
     KeboolaMcpServer,
     SessionParams,
     SessionState,
     SessionStateFactory,
 )
-from .client import KeboolaClient
-from .config import Config
-from .database import ConnectionManager, DatabasePathManager
 
 logger = logging.getLogger(__name__)
 
@@ -107,50 +105,7 @@ def create_server(config: Optional[Config] = None) -> FastMCP:
         ],
     )
 
-    @mcp.tool()
-    async def query_table(sql_query: str, ctx: Context) -> str:
-        """
-        Execute a SQL query through the proxy service to get data from Storage.
-        Before forming the query always check the get_table_metadata tool to get
-        the correct database name and table name.
-        - The {{db_identifier}} is available in the tool response.
-
-        Note: SQL queries must include the full path including database name, e.g.:
-        'SELECT * FROM {{db_identifier}}."test_identify"'. Snowflake is case sensitive so always
-        wrap the column names in double quotes.
-        """
-        connection_manager = ctx.session.state["connection_manager"]
-        assert isinstance(connection_manager, ConnectionManager)
-
-        conn = None
-        cursor = None
-
-        try:
-            conn = connection_manager.create_snowflake_connection()
-            cursor = conn.cursor()
-            cursor.execute(sql_query)
-            result = cursor.fetchall()
-            columns = [col[0] for col in cursor.description]
-
-            # Convert to CSV
-            output = StringIO()
-            writer = csv.writer(output)
-            writer.writerow(columns)
-            writer.writerows(result)
-
-            return output.getvalue()
-
-        except snowflake.connector.errors.ProgrammingError as e:
-            raise ValueError(f"Snowflake query error: {str(e)}")
-
-        except Exception as e:
-            raise ValueError(f"Unexpected error during query execution: {str(e)}")
-
-        finally:
-            if cursor:
-                cursor.close()
-            if conn:
-                conn.close()
+    mcp.add_tool(sql_tools.query_table)
 
     # Tools
     @mcp.tool()
@@ -205,6 +160,7 @@ def create_server(config: Optional[Config] = None) -> FastMCP:
 
         db_path_manager = ctx.session.state["db_path_manager"]
         assert isinstance(db_path_manager, DatabasePathManager)
+        table_fqn = db_path_manager.get_table_fqn(table) or "N/A"
 
         return (
             f"Table Information:\n"
@@ -215,9 +171,7 @@ def create_server(config: Optional[Config] = None) -> FastMCP:
             f"Row Count: {table['rowsCount']}\n"
             f"Data Size: {table['dataSizeBytes']} bytes\n"
             f"Columns: {', '.join(str(ci) for ci in column_info)}\n"
-            f"Database Identifier: {db_path_manager.get_table_db_path(table)}\n"
-            f"Schema: {table['id'].split('.')[0]}\n"
-            f"Table: {table['id'].split('.')[1]}"
+            f"Fully qualified table name: {table_fqn.snowflake_fqn}"
         )
 
     @mcp.tool()

--- a/src/keboola_mcp_server/sql_tools.py
+++ b/src/keboola_mcp_server/sql_tools.py
@@ -1,0 +1,49 @@
+import csv
+from io import StringIO
+from typing import Annotated
+
+import snowflake
+from mcp.server.fastmcp import Context
+from pydantic import Field
+
+from keboola_mcp_server.database import ConnectionManager
+
+
+async def query_table(
+    sql_query: Annotated[str, Field(description="SQL SELECT query to run.")], ctx: Context
+) -> Annotated[str, Field(description="The retrieved data in a CSV format.")]:
+    """
+    Executes an SQL SELECT query to get the data from the underlying snowflake database.
+    * When constructing the SQL SELECT query make sure to use the fully qualified table names
+      that include the database name, schema name and the table name.
+    * The fully qualified table name can be found in the table information, use a tool to get the information
+      about tables. The fully qualified table name can be found in the response for that tool.
+    * Snowflake is case-sensitive so always wrap the column names in double quotes.
+
+    Examples:
+    * SQL queries must include the fully qualified table names including the database name, e.g.:
+      SELECT * FROM "db_name"."db_schema_name"."table_name";
+    """
+    connection_manager = ctx.session.state["connection_manager"]
+    assert isinstance(connection_manager, ConnectionManager)
+
+    with connection_manager.create_snowflake_connection() as conn:
+        try:
+            cursor = conn.cursor()
+            cursor.execute(sql_query)
+            result = cursor.fetchall()
+            columns = [col[0] for col in cursor.description]
+
+            # Convert to CSV
+            output = StringIO()
+            writer = csv.writer(output)
+            writer.writerow(columns)
+            writer.writerows(result)
+
+            return output.getvalue()
+
+        except snowflake.connector.errors.ProgrammingError as e:
+            raise ValueError(f"Snowflake query error: {str(e)}")
+
+        except Exception as e:
+            raise ValueError(f"Unexpected error during query execution: {str(e)}")

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,46 @@
+from typing import Any
+
+import pytest
+
+from keboola_mcp_server.config import Config
+from keboola_mcp_server.database import DatabasePathManager, TableFqn
+
+
+class TestDatabasePathManager:
+
+    @pytest.mark.parametrize('table, snowflake_result, expected', [
+        (
+            # table in.c-foo.bar in its own project
+            {'id': 'in.c-foo.bar', 'name': 'bar'},
+            {'current_database': 'db_xyz', 'current_schema': 'workspace_123'},
+            TableFqn(db_name='db_xyz', schema_name='in.c-foo', table_name='bar')
+        ),
+        (
+            # temporary table not in a project, but in the writable schema of the workspace
+            {'id': 'bar', 'name': 'bar'},
+            {'current_database': 'db_xyz', 'current_schema': 'workspace_123'},
+            TableFqn(db_name='db_xyz', schema_name='workspace_123', table_name='bar')
+        ),
+        (
+            # table out.c-baz.bam exported from project 1234 and imported as table in.c-foo.bar in some other project
+            {'id': 'in.c-foo.bar', 'name': 'bar', 'sourceTable': {'project': {'id': '1234'}, 'id': 'out.c-baz.bam'}},
+            {'name': 'sapi_1234'},
+            TableFqn(db_name='sapi_1234', schema_name='out.c-baz', table_name='bam')
+        ),
+    ])
+    def test_get_table_fqn(
+            self, table: dict[str, Any], snowflake_result: dict[str, Any], expected: TableFqn, mocker
+    ):
+        conn = mocker.MagicMock()
+        conn.__enter__.return_value = conn
+        conn.connect.return_value = conn
+        conn.cursor.return_value = (cursor := mocker.MagicMock())
+        cursor.execute.return_value = (result := mocker.MagicMock())
+        result.fetchone.return_value = snowflake_result
+
+        cm = mocker.patch('keboola_mcp_server.database.ConnectionManager')
+        cm.create_snowflake_connection.return_value = conn
+
+        dpm = DatabasePathManager(config=Config(), connection_manager=cm)
+        fqn = dpm.get_table_fqn(table)
+        assert fqn == expected

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -8,28 +8,35 @@ from keboola_mcp_server.database import DatabasePathManager, TableFqn
 
 class TestDatabasePathManager:
 
-    @pytest.mark.parametrize('table, snowflake_result, expected', [
-        (
-            # table in.c-foo.bar in its own project
-            {'id': 'in.c-foo.bar', 'name': 'bar'},
-            {'current_database': 'db_xyz', 'current_schema': 'workspace_123'},
-            TableFqn(db_name='db_xyz', schema_name='in.c-foo', table_name='bar')
-        ),
-        (
-            # temporary table not in a project, but in the writable schema of the workspace
-            {'id': 'bar', 'name': 'bar'},
-            {'current_database': 'db_xyz', 'current_schema': 'workspace_123'},
-            TableFqn(db_name='db_xyz', schema_name='workspace_123', table_name='bar')
-        ),
-        (
-            # table out.c-baz.bam exported from project 1234 and imported as table in.c-foo.bar in some other project
-            {'id': 'in.c-foo.bar', 'name': 'bar', 'sourceTable': {'project': {'id': '1234'}, 'id': 'out.c-baz.bam'}},
-            {'name': 'sapi_1234'},
-            TableFqn(db_name='sapi_1234', schema_name='out.c-baz', table_name='bam')
-        ),
-    ])
+    @pytest.mark.parametrize(
+        "table, snowflake_result, expected",
+        [
+            (
+                # table in.c-foo.bar in its own project
+                {"id": "in.c-foo.bar", "name": "bar"},
+                {"current_database": "db_xyz", "current_schema": "workspace_123"},
+                TableFqn(db_name="db_xyz", schema_name="in.c-foo", table_name="bar"),
+            ),
+            (
+                # temporary table not in a project, but in the writable schema of the workspace
+                {"id": "bar", "name": "bar"},
+                {"current_database": "db_xyz", "current_schema": "workspace_123"},
+                TableFqn(db_name="db_xyz", schema_name="workspace_123", table_name="bar"),
+            ),
+            (
+                # table out.c-baz.bam exported from project 1234 and imported as table in.c-foo.bar in some other project
+                {
+                    "id": "in.c-foo.bar",
+                    "name": "bar",
+                    "sourceTable": {"project": {"id": "1234"}, "id": "out.c-baz.bam"},
+                },
+                {"name": "sapi_1234"},
+                TableFqn(db_name="sapi_1234", schema_name="out.c-baz", table_name="bam"),
+            ),
+        ],
+    )
     def test_get_table_fqn(
-            self, table: dict[str, Any], snowflake_result: dict[str, Any], expected: TableFqn, mocker
+        self, table: dict[str, Any], snowflake_result: dict[str, Any], expected: TableFqn, mocker
     ):
         conn = mocker.MagicMock()
         conn.__enter__.return_value = conn
@@ -38,7 +45,7 @@ class TestDatabasePathManager:
         cursor.execute.return_value = (result := mocker.MagicMock())
         result.fetchone.return_value = snowflake_result
 
-        cm = mocker.patch('keboola_mcp_server.database.ConnectionManager')
+        cm = mocker.patch("keboola_mcp_server.database.ConnectionManager")
         cm.create_snowflake_connection.return_value = conn
 
         dpm = DatabasePathManager(config=Config(), connection_manager=cm)


### PR DESCRIPTION
This change makes the use of the real database names fetched from the Snowflake connection to create the fully qualified name of a Keboola table rather than just guessing it. This gives the LLM a chance to generate SQL queries with the correct table names.