### PR TITLE
Kab 904 mcp using wsl readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,48 @@ To use this server with Cursor AI, you have two options for configuring the tran
 }
 ```
 
+### Option 3: Using WSL Standard I/O (wsl stdio)
+
+```json
+{
+  "mcpServers": {
+    "keboola_wsl": {
+        "command": "wsl.exe",
+        "args": [
+            "bash",
+            "-c",
+            "'source ~/wsl/path/to/the/script/run_mcp.sh'"
+        ],
+    }
+  }
+}
+```
+
+- where `run_mcp.sh` follows:
+```shell
+#!/bin/bash
+
+PATH_TO_THE_ENV_VARS=~/wsl/path/to/the/file/.env
+PATH_TO_VENV=~/wsl/path/to/the/virtual/environment
+
+source $PATH_TO_THE_ENV_VARS
+$PATH_TO_VENV/bin/python3 -m keboola_mcp_server.cli --log-level DEBUG --api-url https://connection.keboola.com
+```
+
+- and where `.env` file contains following lines
+
+```shell
+export KBC_STORAGE_TOKEN="your-keboola-storage-token"
+export PYTHONPATH="/path/to/your/project/src"
+export KBC_SNOWFLAKE_ACCOUNT="your-snowflake-account"
+export KBC_SNOWFLAKE_USER="your-snowflake-user"
+export KBC_SNOWFLAKE_PASSWORD="your-snowflake-password"
+export KBC_SNOWFLAKE_WAREHOUSE="your-snowflake-warehouse"
+export KBC_SNOWFLAKE_DATABASE="your-snowflake-database"
+export KBC_SNOWFLAKE_SCHEMA="your-snowflake-schema"
+export KBC_SNOWFLAKE_ROLE="your-snowflake-role"
+```
+
 Replace all placeholder values (YOUR_*) with your actual Keboola and Snowflake credentials. These can be obtained from your Keboola project's Read Only Snowflake Workspace.
 
 After updating the configuration:

--- a/README.md
+++ b/README.md
@@ -173,7 +173,8 @@ When running the MCP server from Windows Subsystem for Linux with Cursor AI, use
       "args": [
         "bash",
         "-c",
-        "'source /wsl_path/to/keboola-mcp-server/.env &&",
+        "'source /wsl_path/to/keboola-mcp-server/.env",
+        "&&",
         "/wsl_path/to/keboola-mcp-server/venv/bin/python -m keboola_mcp_server.cli --transport stdio'"
       ]
     }

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ When running the MCP server from Windows Subsystem for Linux with Cursor AI, use
 }
 ```
 
-- where `run_mcp.sh` includes:
+- where `run_mcp.sh` includes: (don't forget to add permissions with cmd: `chmod +x /wsl/path/to/the/run_mcp.sh`)
 ```shell
 #!/bin/bash
 source /wsl/path/to/the/file/.env

--- a/README.md
+++ b/README.md
@@ -165,18 +165,18 @@ To use this server with Cursor AI, you have two options for configuring the tran
 ```
 
 ### Option 2b: Using WSL Standard I/O (wsl stdio)
-When running the MCP server from Windows Subsystem for Linux, use this.
+When running the MCP server from Windows Subsystem for Linux with Cursor AI, use this.
 
 ```json
 {
   "mcpServers": {
     "keboola_wsl": {
-        "command": "wsl.exe",
-        "args": [
-            "bash",
-            "-c",
-            "'source ~/wsl/path/to/the/script/run_mcp.sh'"
-        ],
+      "command": "wsl.exe",
+      "args": [
+        "bash",
+        "-c",
+        "'source /wsl/path/to/the/script/run_mcp.sh'"
+      ],
     }
   }
 }
@@ -190,7 +190,6 @@ source /wsl/path/to/the/file/.env
 ```
 
 - and where `.env` file contains following lines
-
 ```shell
 export KBC_STORAGE_TOKEN="your-keboola-storage-token"
 export PYTHONPATH="/wsl/path/to/your/project/src"

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ To use this server with Cursor AI, you have two options for configuring the tran
 1. Create or edit the Cursor AI configuration file:
    - Location: `~/.cursor/mcp.json`
 
-2. Add one of the following configurations (or both) based on your preferred transport method:
+2. Add one of the following configurations (or all) based on your preferred transport method:
 
 ### Option 1: Using Server-Sent Events (SSE)
 
@@ -137,7 +137,7 @@ To use this server with Cursor AI, you have two options for configuring the tran
 }
 ```
 
-### Option 2: Using Standard I/O (stdio)
+### Option 2a: Using Standard I/O (stdio)
 
 ```json
 {
@@ -164,7 +164,8 @@ To use this server with Cursor AI, you have two options for configuring the tran
 }
 ```
 
-### Option 3: Using WSL Standard I/O (wsl stdio)
+### Option 2b: Using WSL Standard I/O (wsl stdio)
+When running the MCP server from Windows Subsystem for Linux, use this.
 
 ```json
 {
@@ -181,22 +182,18 @@ To use this server with Cursor AI, you have two options for configuring the tran
 }
 ```
 
-- where `run_mcp.sh` follows:
+- where `run_mcp.sh` includes:
 ```shell
 #!/bin/bash
-
-PATH_TO_THE_ENV_VARS=~/wsl/path/to/the/file/.env
-PATH_TO_VENV=~/wsl/path/to/the/virtual/environment
-
-source $PATH_TO_THE_ENV_VARS
-$PATH_TO_VENV/bin/python3 -m keboola_mcp_server.cli --log-level DEBUG --api-url https://connection.keboola.com
+source /wsl/path/to/the/file/.env
+/wsl/path/to/keboola-mcp-server/.venv/bin/python -m keboola_mcp_server.cli --log-level DEBUG --api-url https://connection.keboola.com
 ```
 
 - and where `.env` file contains following lines
 
 ```shell
 export KBC_STORAGE_TOKEN="your-keboola-storage-token"
-export PYTHONPATH="/path/to/your/project/src"
+export PYTHONPATH="/wsl/path/to/your/project/src"
 export KBC_SNOWFLAKE_ACCOUNT="your-snowflake-account"
 export KBC_SNOWFLAKE_USER="your-snowflake-user"
 export KBC_SNOWFLAKE_PASSWORD="your-snowflake-password"

--- a/README.md
+++ b/README.md
@@ -184,7 +184,6 @@ When running the MCP server from Windows Subsystem for Linux with Cursor AI, use
 - where `/wsl_path/to/keboola-mcp-server/.env` file contains environment variables:
 ```shell
 export KBC_STORAGE_TOKEN="your-keboola-storage-token"
-export PYTHONPATH="/wsl_path/to/keboola-mcp-server/src"
 export KBC_SNOWFLAKE_ACCOUNT="your-snowflake-account"
 export KBC_SNOWFLAKE_USER="your-snowflake-user"
 export KBC_SNOWFLAKE_PASSWORD="your-snowflake-password"

--- a/README.md
+++ b/README.md
@@ -170,29 +170,22 @@ When running the MCP server from Windows Subsystem for Linux with Cursor AI, use
 ```json
 {
   "mcpServers": {
-    "keboola_wsl": {
+    "keboola": {
       "command": "wsl.exe",
       "args": [
         "bash",
         "-c",
-        "'source /wsl/path/to/the/script/run_mcp.sh'"
-      ],
+        "'source /wsl_path/to/keboola-mcp-server/.env &&",
+        "/wsl_path/to/keboola-mcp-server/venv/bin/python -m keboola_mcp_server.cli --transport stdio'"
+      ]
     }
   }
 }
 ```
-
-- where `run_mcp.sh` includes: (don't forget to add permissions with cmd: `chmod +x /wsl/path/to/the/run_mcp.sh`)
-```shell
-#!/bin/bash
-source /wsl/path/to/the/file/.env
-/wsl/path/to/keboola-mcp-server/.venv/bin/python -m keboola_mcp_server.cli --log-level DEBUG --api-url https://connection.keboola.com
-```
-
-- and where `.env` file contains following lines
+- where `/wsl_path/to/keboola-mcp-server/.env` file contains environment variables:
 ```shell
 export KBC_STORAGE_TOKEN="your-keboola-storage-token"
-export PYTHONPATH="/wsl/path/to/your/project/src"
+export PYTHONPATH="/wsl_path/to/keboola-mcp-server/src"
 export KBC_SNOWFLAKE_ACCOUNT="your-snowflake-account"
 export KBC_SNOWFLAKE_USER="your-snowflake-user"
 export KBC_SNOWFLAKE_PASSWORD="your-snowflake-password"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "0.1.2"
+version = "0.1.3"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
This PR is a copy of the previous one adding instructions to readme on how to run mcp server from WSL, but with a correct Jira task ID and minor changes which facilitate the usage.
-> The script wrapper that was supposed to run the mcp server is removed since it can be accomplished with raw commands.
-> The problem I had was that the script commands which are used in the WSLinux has to be encapsulated with ' quotes because the Windows and Linux have slightly different line parsers, and windows parsed the arguments which were expected to be passed to Linux parser - the single quotes solved this.