### PR TITLE
add query_table tool back in

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "keboola-mcp-server"
 
-version = "0.2.1"
+version = "0.2.2"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/server.py
+++ b/src/keboola_mcp_server/server.py
@@ -13,7 +13,7 @@ from keboola_mcp_server.mcp import (
     SessionState,
     SessionStateFactory,
 )
-from keboola_mcp_server.sql_tools import WorkspaceManager
+from keboola_mcp_server.sql_tools import WorkspaceManager, add_sql_tools
 from keboola_mcp_server.storage_tools import add_storage_tools
 
 logger = logging.getLogger(__name__)
@@ -75,6 +75,7 @@ def create_server(config: Optional[Config] = None) -> FastMCP:
     )
 
     add_storage_tools(mcp)
+    add_sql_tools(mcp)
 
     @mcp.tool()
     async def list_components(ctx: Context) -> str:

--- a/src/keboola_mcp_server/sql_tools.py
+++ b/src/keboola_mcp_server/sql_tools.py
@@ -3,13 +3,20 @@ import logging
 from io import StringIO
 from typing import Annotated, Any, Literal, Mapping, Optional, Sequence
 
-from mcp.server.fastmcp import Context
+from mcp.server.fastmcp import Context, FastMCP
 from pydantic import Field, TypeAdapter
 from pydantic.dataclasses import dataclass
 
 from keboola_mcp_server.client import KeboolaClient
 
 LOG = logging.getLogger(__name__)
+
+
+def add_sql_tools(mcp: FastMCP) -> None:
+    """Add tools to the MCP server."""
+    mcp.add_tool(query_table)
+
+    logger.info("SQL tools added to the MCP server.")
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
During the latest refactor, the `query_table` has been lost from the MCP server. This PR is concerned with adding it back in.