### PR TITLE
Kab 873 start a component job tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "0.8.0"
+version = "0.9.0"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/client.py
+++ b/src/keboola_mcp_server/client.py
@@ -256,6 +256,33 @@ class JobsQueue(Endpoint):
         }
         return self._search(params=params)
 
+    def create(
+        self,
+        component_id: str,
+        configuration_id: str,
+        mode: str = "run",
+        configuration_row_ids: Optional[List[str]] = None,
+    ) -> Annotated[
+        Dict[str, Any],
+        "The response from the API call - created job or raise an error.",
+    ]:
+        """
+        Create a new Basic job.
+        :param component_id: The id of the component.
+        :param configuration_id: The id of the configuration.
+        :param mode: The mode of the job.
+        :param configuration_row_ids: The row ids of the configuration.
+        :return: The response from the API call - created job or raise an error.
+        """
+        url = f"{self.base_url}/jobs"
+        body = {
+            "component": component_id,
+            "config": configuration_id,
+            "mode": mode,
+            "configRowIds": configuration_row_ids,
+        }
+        return self._post(url, data=body)
+
     def _search(self, params: Dict[str, Any], **kwargs) -> Dict[str, Any]:
         """
         Search for jobs based on the provided parameters.

--- a/src/keboola_mcp_server/client.py
+++ b/src/keboola_mcp_server/client.py
@@ -275,13 +275,13 @@ class JobsQueue(Endpoint):
         :return: The response from the API call - created job or raise an error.
         """
         url = f"{self.base_url}/jobs"
-        body = {
+        payload = {
             "component": component_id,
             "config": configuration_id,
             "mode": mode,
             "configRowIds": configuration_row_ids,
         }
-        return self._post(url, data=body)
+        return self._post(url, json=payload)
 
     def _search(self, params: Dict[str, Any], **kwargs) -> Dict[str, Any]:
         """

--- a/src/keboola_mcp_server/client.py
+++ b/src/keboola_mcp_server/client.py
@@ -256,7 +256,7 @@ class JobsQueue(Endpoint):
         }
         return self._search(params=params)
 
-    def create(
+    def create_job(
         self,
         component_id: str,
         configuration_id: str,
@@ -267,7 +267,7 @@ class JobsQueue(Endpoint):
         "The response from the API call - created job or raise an error.",
     ]:
         """
-        Create a new Basic job.
+        Create a new job.
         :param component_id: The id of the component.
         :param configuration_id: The id of the configuration.
         :param mode: The mode of the job.

--- a/src/keboola_mcp_server/client.py
+++ b/src/keboola_mcp_server/client.py
@@ -260,26 +260,18 @@ class JobsQueue(Endpoint):
         self,
         component_id: str,
         configuration_id: str,
-        mode: str = "run",
-        configuration_row_ids: Optional[List[str]] = None,
-    ) -> Annotated[
-        Dict[str, Any],
-        "The response from the API call - created job or raise an error.",
-    ]:
+    ) -> Dict[str, Any]:
         """
         Create a new job.
         :param component_id: The id of the component.
         :param configuration_id: The id of the configuration.
-        :param mode: The mode of the job.
-        :param configuration_row_ids: The row ids of the configuration.
         :return: The response from the API call - created job or raise an error.
         """
         url = f"{self.base_url}/jobs"
         payload = {
             "component": component_id,
             "config": configuration_id,
-            "mode": mode,
-            "configRowIds": configuration_row_ids,
+            "mode": "run",
         }
         return self._post(url, json=payload)
 

--- a/src/keboola_mcp_server/jobs_tools.py
+++ b/src/keboola_mcp_server/jobs_tools.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 ################################## Add jobs tools to MCP SERVER ##################################
 
+
 def add_jobs_tools(mcp: FastMCP) -> None:
     """Add tools to the MCP server."""
     jobs_tools = [

--- a/src/keboola_mcp_server/jobs_tools.py
+++ b/src/keboola_mcp_server/jobs_tools.py
@@ -260,7 +260,8 @@ async def get_job_detail(
 async def start_job(
     ctx: Context,
     component_id: Annotated[
-        str, Field(description="The ID of the component or transformation for which to start a job.")
+        str,
+        Field(description="The ID of the component or transformation for which to start a job."),
     ],
     configuration_id: Annotated[
         str, Field(description="The ID of the configuration for which to start a job.")

--- a/src/keboola_mcp_server/jobs_tools.py
+++ b/src/keboola_mcp_server/jobs_tools.py
@@ -9,6 +9,20 @@ from keboola_mcp_server.client import KeboolaClient
 
 logger = logging.getLogger(__name__)
 
+
+def add_jobs_tools(mcp: FastMCP) -> None:
+    """Add tools to the MCP server."""
+    jobs_tools = [
+        retrieve_jobs,
+        get_job_detail,
+        start_new_job,
+    ]
+    for tool in jobs_tools:
+        logger.info(f"Adding tool {tool.__name__} to the MCP server.")
+        mcp.add_tool(tool)
+
+    logger.info("Jobs tools initialized.")
+
 ######################################## Job Base Models ########################################
 
 JOB_STATUS = Literal[
@@ -132,19 +146,6 @@ class JobDetail(JobListItem):
 
 SORT_BY_VALUES = Literal["startTime", "endTime", "createdTime", "durationSeconds", "id"]
 SORT_ORDER_VALUES = Literal["asc", "desc"]
-
-
-def add_jobs_tools(mcp: FastMCP) -> None:
-    """Add tools to the MCP server."""
-    jobs_tools = [
-        retrieve_jobs,
-        get_job_detail,
-    ]
-    for tool in jobs_tools:
-        logger.info(f"Adding tool {tool.__name__} to the MCP server.")
-        mcp.add_tool(tool)
-
-    logger.info("Jobs tools initialized.")
 
 
 async def retrieve_jobs(

--- a/src/keboola_mcp_server/jobs_tools.py
+++ b/src/keboola_mcp_server/jobs_tools.py
@@ -3,7 +3,7 @@ import logging
 from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 
 from mcp.server.fastmcp import Context, FastMCP
-from pydantic import AliasChoices, BaseModel, Field, ValidationError, field_validator
+from pydantic import AliasChoices, BaseModel, Field, field_validator
 
 from keboola_mcp_server.client import KeboolaClient
 
@@ -134,9 +134,7 @@ class JobDetail(JobListItem):
         if not current_value:
             return dict()
         if isinstance(current_value, list):
-            raise ValidationError(
-                f"Field 'result' cannot be a list, expecting dictionary, got: {current_value}."
-            )
+            raise ValueError(f"Field 'result' cannot be a list, expecting dictionary, got: {current_value}.")
         return current_value
 
 

--- a/src/keboola_mcp_server/jobs_tools.py
+++ b/src/keboola_mcp_server/jobs_tools.py
@@ -10,12 +10,14 @@ from keboola_mcp_server.client import KeboolaClient
 logger = logging.getLogger(__name__)
 
 
+################################## Add jobs tools to MCP SERVER ##################################
+
 def add_jobs_tools(mcp: FastMCP) -> None:
     """Add tools to the MCP server."""
     jobs_tools = [
         retrieve_jobs,
         get_job_detail,
-        start_new_job,
+        run_job,
     ]
     for tool in jobs_tools:
         logger.info(f"Adding tool {tool.__name__} to the MCP server.")
@@ -253,7 +255,7 @@ async def get_job_detail(
     return JobDetail.model_validate(raw_job)
 
 
-async def start_new_job(
+async def run_job(
     ctx: Context,
     component_id: Annotated[
         str, Field(description="The ID of the component or transformation to run.")
@@ -261,7 +263,7 @@ async def start_new_job(
     configuration_id: Annotated[str, Field(description="The ID of the configuration to run.")],
 ) -> Annotated[JobDetail, Field(description="The newly created job detail.")]:
     """
-    Starts a new job for a given component or transformation.
+    Runs a new job for a given component or transformation.
     """
     client = KeboolaClient.from_state(ctx.session.state)
 

--- a/src/keboola_mcp_server/jobs_tools.py
+++ b/src/keboola_mcp_server/jobs_tools.py
@@ -266,7 +266,9 @@ async def start_new_job(
     client = KeboolaClient.from_state(ctx.session.state)
 
     try:
-        raw_job = client.jobs_queue.create(component_id, configuration_id)
+        raw_job = client.jobs_queue.create(
+            component_id=component_id, configuration_id=configuration_id
+        )
         job = JobDetail.model_validate(raw_job)
         logger.info(
             f"Started a new job with id: {job.id} for component {component_id} and configuration {configuration_id}."

--- a/src/keboola_mcp_server/jobs_tools.py
+++ b/src/keboola_mcp_server/jobs_tools.py
@@ -241,4 +241,30 @@ async def get_job_detail(
     return JobDetail.model_validate(raw_job)
 
 
+async def start_new_job(
+    ctx: Context,
+    component_id: Annotated[
+        str, Field(description="The ID of the component or transformation to run.")
+    ],
+    configuration_id: Annotated[str, Field(description="The ID of the configuration to run.")],
+) -> Annotated[JobDetail, Field(description="The newly created job detail.")]:
+    """
+    Starts a new job for a given component or transformation.
+    """
+    client = KeboolaClient.from_state(ctx.session.state)
+
+    try:
+        raw_job = client.jobs_queue.create(component_id, configuration_id)
+        job = JobDetail.model_validate(raw_job)
+        logger.info(
+            f"Started a new job with id: {job.id} for component {component_id} and configuration {configuration_id}."
+        )
+        return job
+    except Exception as e:
+        logger.exception(
+            f"Error when starting a new job for component {component_id} and configuration {configuration_id}: {e}"
+        )
+        raise e
+
+
 ######################################## End of MCP tools ########################################

--- a/src/keboola_mcp_server/jobs_tools.py
+++ b/src/keboola_mcp_server/jobs_tools.py
@@ -23,6 +23,7 @@ def add_jobs_tools(mcp: FastMCP) -> None:
 
     logger.info("Jobs tools initialized.")
 
+
 ######################################## Job Base Models ########################################
 
 JOB_STATUS = Literal[
@@ -134,7 +135,9 @@ class JobDetail(JobListItem):
         if not current_value:
             return dict()
         if isinstance(current_value, list):
-            raise ValueError(f"Field 'result' cannot be a list, expecting dictionary, got: {current_value}.")
+            raise ValueError(
+                f"Field 'result' cannot be a list, expecting dictionary, got: {current_value}."
+            )
         return current_value
 
 

--- a/src/keboola_mcp_server/server.py
+++ b/src/keboola_mcp_server/server.py
@@ -8,7 +8,7 @@ from mcp.server.fastmcp import FastMCP
 from keboola_mcp_server.client import KeboolaClient
 from keboola_mcp_server.component_tools import add_component_tools
 from keboola_mcp_server.config import Config
-from keboola_mcp_server.jobs_tools import add_jobs_tools
+from keboola_mcp_server.jobs_tools import add_job_tools
 from keboola_mcp_server.mcp import (
     KeboolaMcpServer,
     SessionParams,
@@ -71,7 +71,7 @@ def create_server(config: Optional[Config] = None) -> FastMCP:
     # Add component tools to the server inplace.
     add_component_tools(mcp)
     # Add jobs tools to the server inplace.
-    add_jobs_tools(mcp)
+    add_job_tools(mcp)
 
     add_storage_tools(mcp)
     add_sql_tools(mcp)

--- a/tests/test_jobs_tools.py
+++ b/tests/test_jobs_tools.py
@@ -12,7 +12,7 @@ from keboola_mcp_server.jobs_tools import (
     JobListItem,
     get_job_detail,
     retrieve_jobs,
-    start_new_job,
+    run_job,
 )
 
 
@@ -234,8 +234,8 @@ async def retrieve_jobs_with_component_id_without_config_id(
 
 
 @pytest.mark.asyncio
-async def test_start_new_job(mcp_context_client: Context, mock_job: dict[str, Any]):
-    """Tests start_new_job tool."""
+async def test_run_job(mcp_context_client: Context, mock_job: dict[str, Any]):
+    """Tests run_job tool."""
     context = mcp_context_client
     keboola_client = KeboolaClient.from_state(context.session.state)
     mock_job["result"] = []  # simulate empty list as returned by create job endpoint
@@ -244,7 +244,7 @@ async def test_start_new_job(mcp_context_client: Context, mock_job: dict[str, An
 
     component_id = mock_job["component"]
     configuration_id = mock_job["config"]
-    job_detail = await start_new_job(
+    job_detail = await run_job(
         ctx=context, component_id=component_id, configuration_id=configuration_id
     )
 
@@ -263,8 +263,8 @@ async def test_start_new_job(mcp_context_client: Context, mock_job: dict[str, An
 
 
 @pytest.mark.asyncio
-async def test_start_new_job_failed(mcp_context_client: Context, mock_job: dict[str, Any]):
-    """Tests start_new_job tool when job creation fails."""
+async def test_run_job_fail(mcp_context_client: Context, mock_job: dict[str, Any]):
+    """Tests run_job tool when job creation fails."""
     context = mcp_context_client
     keboola_client = KeboolaClient.from_state(context.session.state)
     keboola_client.jobs_queue.create = MagicMock(side_effect=HTTPError("Job creation failed"))
@@ -273,7 +273,7 @@ async def test_start_new_job_failed(mcp_context_client: Context, mock_job: dict[
     configuration_id = mock_job["config"]
 
     with pytest.raises(HTTPError):
-        await start_new_job(
+        await run_job(
             ctx=context, component_id=component_id, configuration_id=configuration_id
         )
 

--- a/tests/test_jobs_tools.py
+++ b/tests/test_jobs_tools.py
@@ -281,9 +281,7 @@ async def test_start_job_fail(mcp_context_client: Context, mock_job: dict[str, A
     configuration_id = mock_job["config"]
 
     with pytest.raises(HTTPError):
-        await start_job(
-            ctx=context, component_id=component_id, configuration_id=configuration_id
-        )
+        await start_job(ctx=context, component_id=component_id, configuration_id=configuration_id)
 
     keboola_client.jobs_queue.create_job.assert_called_once_with(
         component_id=component_id,

--- a/tests/test_jobs_tools.py
+++ b/tests/test_jobs_tools.py
@@ -1,8 +1,9 @@
 from datetime import datetime
-from typing import Any, List, Type, Union
+from typing import Any, Type, Union
 from unittest.mock import MagicMock
 
 import pytest
+from httpx import HTTPError
 from mcp.server.fastmcp import Context
 
 from keboola_mcp_server.client import KeboolaClient
@@ -11,6 +12,7 @@ from keboola_mcp_server.jobs_tools import (
     JobListItem,
     get_job_detail,
     retrieve_jobs,
+    start_new_job,
 )
 
 
@@ -230,15 +232,78 @@ async def retrieve_jobs_with_component_id_without_config_id(
         sort_order="desc",
     )
 
-@pytest.mark.parametrize("result_type, is_exception, expected_result", [
-    ([], False, {}), # empty list is not a valid result type but we convert it to {}, no error
-    ({}, False, {}), # expected empty dict, no error
-    ({"result": []}, False, {"result": []}), # expected result type, no error
-    (None, False, {}), # None is valid and converted to {}
-    (["result1", "result2"], True, ValueError), # list is not a valid result type, we raise an error
-])
-def test_input_data(result_type: Union[list, dict, None], is_exception: bool, expected_result: Union[dict, Type[Exception]],
-                    mock_job: dict[str, Any]):
+
+@pytest.mark.asyncio
+async def test_start_new_job(mcp_context_client: Context, mock_job: dict[str, Any]):
+    """Tests start_new_job tool."""
+    context = mcp_context_client
+    keboola_client = KeboolaClient.from_state(context.session.state)
+    mock_job["result"] = []  # simulate empty list as returned by create job endpoint
+    mock_job["status"] = "created"  # simulate created status as returned by create job endpoint
+    keboola_client.jobs_queue.create = MagicMock(return_value=mock_job)
+
+    component_id = mock_job["component"]
+    configuration_id = mock_job["config"]
+    job_detail = await start_new_job(
+        ctx=context, component_id=component_id, configuration_id=configuration_id
+    )
+
+    assert isinstance(job_detail, JobDetail)
+    assert job_detail.result == {}
+    assert job_detail.id == mock_job["id"]
+    assert job_detail.status == mock_job["status"]
+    assert job_detail.component_id == component_id
+    assert job_detail.config_id == configuration_id
+    assert job_detail.result == {}
+
+    keboola_client.jobs_queue.create.assert_called_once_with(
+        component_id=component_id,
+        configuration_id=configuration_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_new_job_failed(mcp_context_client: Context, mock_job: dict[str, Any]):
+    """Tests start_new_job tool when job creation fails."""
+    context = mcp_context_client
+    keboola_client = KeboolaClient.from_state(context.session.state)
+    keboola_client.jobs_queue.create = MagicMock(side_effect=HTTPError("Job creation failed"))
+
+    component_id = mock_job["component"]
+    configuration_id = mock_job["config"]
+
+    with pytest.raises(HTTPError):
+        await start_new_job(
+            ctx=context, component_id=component_id, configuration_id=configuration_id
+        )
+
+    keboola_client.jobs_queue.create.assert_called_once_with(
+        component_id=component_id,
+        configuration_id=configuration_id,
+    )
+
+
+@pytest.mark.parametrize(
+    "result_type, is_exception, expected_result",
+    [
+        ([], False, {}),  # empty list is not a valid result type but we convert it to {}, no error
+        ({}, False, {}),  # expected empty dict, no error
+        ({"result": []}, False, {"result": []}),  # expected result type, no error
+        (None, False, {}),  # None is valid and converted to {}
+        (
+            ["result1", "result2"],
+            True,
+            ValueError,
+        ),  # list is not a valid result type, we raise an error
+    ],
+)
+def test_job_detail_model_validate_for_result_field(
+    result_type: Union[list, dict, None],
+    is_exception: bool,
+    expected_result: Union[dict, Type[Exception]],
+    mock_job: dict[str, Any],
+):
+    """Tests JobDetail model validate for result field."""
     mock_job["result"] = result_type
     if is_exception:
         assert isinstance(expected_result, type) and issubclass(expected_result, Exception)
@@ -247,4 +312,3 @@ def test_input_data(result_type: Union[list, dict, None], is_exception: bool, ex
     else:
         job_detail = JobDetail.model_validate(mock_job)
         assert job_detail.result == expected_result
-

--- a/tests/test_jobs_tools.py
+++ b/tests/test_jobs_tools.py
@@ -273,9 +273,7 @@ async def test_run_job_fail(mcp_context_client: Context, mock_job: dict[str, Any
     configuration_id = mock_job["config"]
 
     with pytest.raises(HTTPError):
-        await run_job(
-            ctx=context, component_id=component_id, configuration_id=configuration_id
-        )
+        await run_job(ctx=context, component_id=component_id, configuration_id=configuration_id)
 
     keboola_client.jobs_queue.create.assert_called_once_with(
         component_id=component_id,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -25,7 +25,7 @@ class TestServer:
             RETRIEVE_COMPONENTS_CONFIGURATIONS_TOOL_NAME,
             "retrieve_jobs",
             RETRIEVE_TRANSFORMATIONS_CONFIGURATIONS_TOOL_NAME,
-            "start_new_job",
+            "run_job",
             "update_bucket_description",
             "update_table_description",
         ]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -14,6 +14,7 @@ class TestServer:
         server = create_server()
         tools = await server.list_tools()
         assert sorted(t.name for t in tools) == [
+            "create_job_run",
             "get_bucket_detail",
             GET_COMPONENT_CONFIGURATION_DETAILS_TOOL_NAME,
             "get_job_detail",
@@ -25,7 +26,6 @@ class TestServer:
             RETRIEVE_COMPONENTS_CONFIGURATIONS_TOOL_NAME,
             "retrieve_jobs",
             RETRIEVE_TRANSFORMATIONS_CONFIGURATIONS_TOOL_NAME,
-            "run_job",
             "update_bucket_description",
             "update_table_description",
         ]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -14,7 +14,6 @@ class TestServer:
         server = create_server()
         tools = await server.list_tools()
         assert sorted(t.name for t in tools) == [
-            "create_job_run",
             "create_sql_transformation",
             "get_bucket_detail",
             GET_COMPONENT_CONFIGURATION_DETAILS_TOOL_NAME,
@@ -27,6 +26,7 @@ class TestServer:
             RETRIEVE_COMPONENTS_CONFIGURATIONS_TOOL_NAME,
             "retrieve_jobs",
             RETRIEVE_TRANSFORMATIONS_CONFIGURATIONS_TOOL_NAME,
+            "start_job",
             "update_bucket_description",
             "update_table_description",
         ]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -25,6 +25,7 @@ class TestServer:
             RETRIEVE_COMPONENTS_CONFIGURATIONS_TOOL_NAME,
             "retrieve_jobs",
             RETRIEVE_TRANSFORMATIONS_CONFIGURATIONS_TOOL_NAME,
+            "start_new_job",
             "update_bucket_description",
             "update_table_description",
         ]


### PR DESCRIPTION
This PR adds a tool for starting a new job to the MCP.  PR also removes `metrics` field from the job detail model as it contains metadata that are irrelevant to the user, but adds a new JOB_STATUS enum field `created` because the newly created job is annotated respectively.

start_new_job tool accepts:
-  component id  = for which component / transformation the job should run
- configuraiton id = for which configuration the job should run
and returns:
- newly created job detail with the new job id.

Question: Should we consider also configuration raw ids in the tool's parameters ?