### PR TITLE
Kab 874 create sql transformation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "0.7.0"
+version = "0.8.0"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/component_tools.py
+++ b/src/keboola_mcp_server/component_tools.py
@@ -707,9 +707,7 @@ async def create_sql_transformation(
     )
 
     client = KeboolaClient.from_state(ctx.session.state)
-    endpoint = (
-        f"branch/{client.storage_client._branch_id}/components/{transformation_id}/configs"
-    )
+    endpoint = f"branch/{client.storage_client._branch_id}/components/{transformation_id}/configs"
 
     logger.info(
         f"Creating new transformation configuration: {name} for component: {transformation_id}."

--- a/src/keboola_mcp_server/component_tools.py
+++ b/src/keboola_mcp_server/component_tools.py
@@ -652,7 +652,7 @@ async def create_sql_transformation(
         Sequence[str],
         Field(
             description=(
-                "The SQL executable query statements written in the current SQL dialect."
+                "The executable SQL query statements written in the current SQL dialect. "
                 "Each statement should be a separate item in the list."
             ),
         ),
@@ -687,10 +687,10 @@ async def create_sql_transformation(
         - Use when you want to create a new SQL transformation.
     EXAMPLES:
         - user_input: `Can you save me the SQL query you generated as a new transformation?`
-            -> set the sql_statement to the query, and set other parameters accordingly.
+            -> set the sql_statements to the query, and set other parameters accordingly.
             -> returns the created SQL transformation configuration if successful.
         - user_input: `Generate me an SQL transformation which [USER INTENT]`
-            -> set the sql_statement to the query based on the [USER INTENT], and set other parameters accordingly.
+            -> set the sql_statements to the query based on the [USER INTENT], and set other parameters accordingly.
             -> returns the created SQL transformation configuration if successful.
     """
 

--- a/src/keboola_mcp_server/component_tools.py
+++ b/src/keboola_mcp_server/component_tools.py
@@ -376,7 +376,10 @@ def _get_sql_transformation_id_from_sql_dialect(
 
 
 class TransformationConfiguration(BaseModel):
-    """The configuration for the transformation serves as a schema for the transformation configuration in the API."""
+    """
+    Utility class to create the transformation configuration, a schema for the transformation configuration in the API.
+    Currently, the storage configuration uses only input and output tables, excluding files, etc.
+    """
 
     class Parameters(BaseModel):
         """The parameters for the transformation."""
@@ -424,28 +427,48 @@ class TransformationConfiguration(BaseModel):
     storage: Storage = Field(description="The storage configuration for the transformation")
 
 
-def _get_transformation_configuration(sql_statement: str) -> TransformationConfiguration:
+def _get_transformation_configuration(
+    statements: Sequence[str], transformation_name: str, output_table_mappings: Sequence[str]
+) -> TransformationConfiguration:
     """
-    Utility function to set the transformation configuration from SQL statement.
+    Utility function to set the transformation configuration from code statements.
     It creates the expected configuration for the transformation, parameters and storage.
-    :param sql_statement: The SQL statements
+    :param statements: The code statements (sql for now)
+    :param transformation_name: The name of the transformation from which the bucket name is derived as in the UI
+    :param output_table_mappings: The output table mappings created tables in the transformation
     :return: dictionary with parameters and storage following the TransformationConfiguration schema
     """
     # init Storage Configuration with empty input and output tables
     storage = TransformationConfiguration.Storage()
-    # build parameters configuration out of SQL statement
+    # build parameters configuration out of code statements
     parameters = TransformationConfiguration.Parameters(
         blocks=[
             TransformationConfiguration.Parameters.Block(
                 name=f"Block 0",
                 codes=[
                     TransformationConfiguration.Parameters.Block.Code(
-                        name=f"Code 0", script=[sql_statement]
+                        name=f"Code 0", script=list(statements)
                     )
                 ],
             )
         ]
     )
+    if output_table_mappings:
+        # if the query creates new tables, output_table_mappings should contain the table names (llm generated)
+        # we create bucket name from the sql query name adding `out.c-` prefix as in the UI and use it as destination
+        # expected output table name format is `out.c-<sql_query_name>.<table_name>`
+        bucket_name = "-".join(transformation_name.lower().split())
+        destination = f"out.c-{bucket_name}"
+        storage.output.tables = [
+            TransformationConfiguration.Storage.Destination.Table(
+                # here the source refers to the table name from the sql statement
+                # and the destination to the full bucket table name
+                # WARNING: when implementing input.tables, source and destination are swapped.
+                source=out_table,
+                destination=f"{destination}.{out_table}",
+            )
+            for out_table in output_table_mappings
+        ]
     return TransformationConfiguration(parameters=parameters, storage=storage)
 
 
@@ -613,7 +636,7 @@ async def create_sql_transformation(
     name: Annotated[
         str,
         Field(
-            description="The name of the SQL transformation expressing the sql functionality.",
+            description="A short, descriptive name summarizing the purpose of the SQL transformation.",
         ),
     ],
     description: Annotated[
@@ -625,12 +648,22 @@ async def create_sql_transformation(
             ),
         ),
     ],
-    sql_statement: Annotated[
-        str,
+    sql_statements: Annotated[
+        Sequence[str],
         Field(
-            description=("The SQL exacutable query statemenet following the current SQL dialect."),
+            description=(
+                "The SQL executable query statements written in the current SQL dialect."
+                "Each statement should be a separate item in the list."
+            ),
         ),
     ],
+    created_table_names: Annotated[
+        Sequence[str],
+        Field(
+            description="An empty list or a list of created table names if and only if they are generated within SQL "
+            "statements (e.g., using `CREATE TABLE ...`).",
+        ),
+    ] = tuple(),
 ) -> Annotated[
     ComponentConfiguration,
     Field(
@@ -638,15 +671,16 @@ async def create_sql_transformation(
     ),
 ]:
     """
-    Creates an SQL transformation using the specified name, SQL query following the current SQL dialect, and a detailed
-    description.
+    Creates an SQL transformation using the specified name, SQL query following the current SQL dialect, a detailed
+    description, and optionally a list of created table names if and only if they are generated within the SQL
+    statements.
     CONSIDERATIONS:
-        - The SQL query statement is executable and must follow the current SQL dialect, which
-          can be retrieved using appropriate tool.
-        - When creating a new table within the SQL query (e.g. CREATE TABLE ...), use only the quoted table name without
-          fully qualified table name.
+        - The SQL query statement is executable and must follow the current SQL dialect, which can be retrieved using
+        appropriate tool.
         - When referring to the input tables within the SQL query, use fully qualified table names, which can be
           retrieved using appropriate tools.
+        - When creating a new table within the SQL query (e.g. CREATE TABLE ...), use only the quoted table name without
+          fully qualified table name, and add the plain table name without quotes to the `created_table_names` list.
         - Unless otherwise specified by user, transformation name and description are generated based on the sql query
           and user intent.
     USAGE:
@@ -666,18 +700,23 @@ async def create_sql_transformation(
     transformation_id = _get_sql_transformation_id_from_sql_dialect(sql_dialect)
     logger.info(f"SQL dialect: {sql_dialect}, using transformation ID: {transformation_id}")
 
-    # Process the data to be stored in the storage configuration
-    transformation_configuration_payload = _get_transformation_configuration(sql_statement)
+    # Process the data to be stored in the transformation configuration - parameters(sql statements)
+    # and storage(input and output tables)
+    transformation_configuration_payload = _get_transformation_configuration(
+        sql_statements, name, created_table_names
+    )
 
     client = KeboolaClient.from_state(ctx.session.state)
-    endpoint = f"branch/{client.storage_client._branch_id}/components/{transformation_id}/configs"
+    endpoint = (
+        f"branch/{client.storage_client._branch_id}/components/{transformation_id}/configs"
+    )
+
+    logger.info(
+        f"Creating new transformation configuration: {name} for component: {transformation_id}."
+    )
     # Try to create the new transformation configuration and return the full object if successful
     # or log an error and raise an exception if not
     try:
-        # Create the new transformation configuration
-        logger.info(
-            f"Creating new transformation configuration: {name} for component: {transformation_id}."
-        )
         new_raw_transformation_configuration = await client.post(
             endpoint,
             data={
@@ -686,12 +725,14 @@ async def create_sql_transformation(
                 "configuration": transformation_configuration_payload.model_dump(),
             },
         )
+
         component = await _get_component_details(client=client, component_id=transformation_id)
         new_transformation_configuration = ComponentConfiguration(
             **new_raw_transformation_configuration,
             component_id=transformation_id,
             component=component,
         )
+
         logger.info(
             f"Created new transformation '{transformation_id}' with configuration id "
             f"'{new_transformation_configuration.configuration_id}'."

--- a/tests/test_component_tools.py
+++ b/tests/test_component_tools.py
@@ -510,8 +510,7 @@ async def test_create_transformation_configuration_fail(
     sql_dialect: str,
     mcp_context_components_configs: Context,
 ):
-    """Test get_transformation_configuration tool which should return the correct transformation configuration
-    given the sql statement."""
+    """Test create_sql_transformation tool which should raise an error if the sql dialect is unknown."""
     context = mcp_context_components_configs
     workspace_manager = WorkspaceManager.from_state(context.session.state)
     workspace_manager.get_sql_dialect = AsyncMock(return_value=sql_dialect)
@@ -534,12 +533,21 @@ async def test_create_transformation_configuration_fail(
         # testing with multiple sql statements and output table mappings
         # it should create output tables according to the mappings
         (
-            ["SELECT * FROM test"],
+            [
+                'CREATE OR REPLACE TABLE "test_table_1" AS SELECT * FROM "test";',
+                'CREATE OR REPLACE TABLE "test_table_2" AS SELECT * FROM "test";',
+            ],
             ["test_table_1", "test_table_2"],
             "test name two",
             "out.c-test-name-two",
         ),
-        (["SELECT * FROM test"], ["test_table_1"], "test", "out.c-test"),
+        # testing with single sql statement and output table mappings
+        (
+            ['CREATE OR REPLACE TABLE "test_table_1" AS SELECT * FROM "test";'],
+            ["test_table_1"],
+            "test name",
+            "out.c-test-name",
+        ),
     ],
 )
 def test_get_transformation_configuration(

--- a/tests/test_component_tools.py
+++ b/tests/test_component_tools.py
@@ -525,7 +525,7 @@ async def test_create_transformation_configuration_fail(
 
 
 @pytest.mark.parametrize(
-    "sql_statements, created_table_names, transformation_name, expected_destination",
+    "sql_statements, created_table_names, transformation_name, expected_bucket_id",
     [
         # testing with multiple sql statements and no output table mappings
         # it should not create any output tables
@@ -554,7 +554,7 @@ def test_get_transformation_configuration(
     sql_statements: list[str],
     created_table_names: list[str],
     transformation_name: str,
-    expected_destination: str,
+    expected_bucket_id: str,
 ):
     """Test get_transformation_configuration tool which should return the correct transformation configuration
     given the sql statement created_table_names and transformation_name."""
@@ -562,7 +562,7 @@ def test_get_transformation_configuration(
     configuration = _get_transformation_configuration(
         statements=sql_statements,
         transformation_name=transformation_name,
-        output_table_mappings=created_table_names,
+        output_tables=created_table_names,
     )
 
     assert configuration is not None
@@ -586,4 +586,4 @@ def test_get_transformation_configuration(
             configuration.storage.output.tables, created_table_names
         ):
             assert created_table.source == expected_table_name
-            assert created_table.destination == f"{expected_destination}.{expected_table_name}"
+            assert created_table.destination == f"{expected_bucket_id}.{expected_table_name}"


### PR DESCRIPTION
This PR adds the missing parameter for specifying created table names within SQL query in the create SQL Transformation tool and enables to configure output mappings directly in the mcp server (automatically). The output bucket name is is derived from the transformation name e.g. `transformation_name='example transformation name' --> bucket_name='example-transformation-name'` and the destination where a created table is stored is then e.g.  `table_name='table-name' ---> destination='out.c-example-transformation-name.table-name'`

now the `create_sql_transformation` tool accepts:
- transformation name (generated by llm if not specified)
- transformation description (generated by llm if not specified)
- sql statements (generated by llm. LLM should consider following: each statement is a separate item in the list and should follow current SQL dialect. Input tables should be referenced by fully qualified ids, created output tables within query should be only names)
- created table names (generated by llm, This list should be empty if no table creation is applied within query otherwise it contains plain table names created in the query)