### PR TITLE
Kab 980 push to pypi org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,10 @@ jobs:
     needs:
       - build
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') && needs.build.outputs.is_semantic_tag == 'true'
+    if: |
+      startsWith(github.ref, 'refs/tags/') &&
+      needs.build.outputs.is_semantic_tag == 'true' &&
+      needs.build.outputs.tag == format('v{0}', needs.build.outputs.version)
     steps:
       - name: Download wheel package
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,19 +96,8 @@ jobs:
           name: keboola_mcp_server-${{ needs.build.outputs.version }}-py3-none-any.whl
           path: dist/
 
-      - name: List dist files
-        run: |
-          ls -la dist/
-
-      - name: Print build outputs
-        run: |
-          echo "is_semantic_tag=${{ needs.build.outputs.is_semantic_tag }}"
-          echo "tag=${{ needs.build.outputs.tag }}"
-          echo "version=${{ needs.build.outputs.version }}"
-          echo "startsWith=${{ startsWith(github.ref, 'refs/tags/') }}"
-
-#      - name: Publish package
-#        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-#        with:
-#          user: __token__
-#          password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Download wheel package
         uses: actions/download-artifact@v4
         with:
-          artifact-ids: ${{ needs.build.outputs.wheel_artifact_id }}
+          name: keboola_mcp_server-${{ needs.build.outputs.version }}-py3-none-any.whl
           path: dist/
 
       - name: List dist files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,7 @@
 name: CI
 
-on:
-  push:
-    branches: [ "**" ]
-  pull_request:
-    branches: [ main ]
+on: [ push ]
+concurrency: ci-${{ github.ref }}
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,13 @@ jobs:
         run: |
           ls -la dist/
 
+      - name: Print build outputs
+        run: |
+          echo "is_semantic_tag=${{ needs.build.outputs.is_semantic_tag }}"
+          echo "tag=${{ needs.build.outputs.tag }}"
+          echo "version=${{ needs.build.outputs.version }}"
+          echo "startsWith=${{ startsWith(github.ref, 'refs/tags/') }}"
+
 #      - name: Publish package
 #        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
 #        with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
     needs:
       - build
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') && needs.build.outputs.is_semantic_tag == 'true' && needs.build.outputs.tag == 'v${{ needs.build.outputs.version }}'
+    if: startsWith(github.ref, 'refs/tags/') && needs.build.outputs.is_semantic_tag == 'true'
     steps:
       - name: Download wheel package
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
-
+    outputs:
+      is_semantic_tag: ${{ steps.get_package_version.outputs.is_semantic_tag }}
+      tag: ${{ steps.get_package_version.outputs.tag }}
+      version: ${{ steps.get_package_version.outputs.version }}
+      wheel_artifact_id: ${{ steps.wheel_artifact_upload.outputs.artifact-id }}
     steps:
       - uses: actions/checkout@v4
 
@@ -58,15 +62,49 @@ jobs:
           python -m build --wheel
 
       - name: Get package version
-        id: get_version
+        id: get_package_version
+        if: matrix.python-version == '3.10'
         run: |
           VERSION=`python3 -c 'import importlib.metadata; print(importlib.metadata.version("keboola_mcp_server"))'`
+          TAG="${GITHUB_REF##*/}"
+          IS_SEMANTIC_TAG=$(echo "$TAG" | grep -q '^v\?[0-9]\+\.[0-9]\+\.[0-9]\+$' && echo true || echo false)
+          echo "Version = '$VERSION', Tag = '$TAG', is semantic tag = '$IS_SEMANTIC_TAG'"
+          echo "is_semantic_tag=$IS_SEMANTIC_TAG" >> $GITHUB_OUTPUT
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Upload wheel package
+        id: wheel_artifact_upload
         if: matrix.python-version == '3.10'
         uses: actions/upload-artifact@v4
         with:
-          name: keboola_mcp_server-${{ steps.get_version.outputs.version }}-${{ github.sha }}-py3-none-any.whl
+          name: keboola_mcp_server-${{ steps.get_version.outputs.version }}-py3-none-any.whl
           path: dist/keboola_mcp_server-${{ steps.get_version.outputs.version }}-py3-none-any.whl
+          if-no-files-found: error
+          compression-level: 0  # wheels are ZIP archives
           retention-days: 7
+
+  deploy_to_pypi:
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    if: >-
+      startsWith(github.ref, 'refs/tags/') && 
+      needs.build.outputs.is_semantic_tag == 'true' && 
+      needs.build.outputs.tag == 'v${{ needs.build.outputs.version }}'
+    steps:
+      - name: Download wheel package
+        uses: actions/download-artifact@v4
+        with:
+          artifact-ids: ${{ needs.build.outputs.wheel_artifact_id }}
+          path: dist/
+
+      - name: List dist files
+        run: |
+          ls -la dist/
+
+#      - name: Publish package
+#        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+#        with:
+#          user: __token__
+#          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,8 @@ jobs:
         if: matrix.python-version == '3.10'
         uses: actions/upload-artifact@v4
         with:
-          name: keboola_mcp_server-${{ steps.get_version.outputs.version }}-py3-none-any.whl
-          path: dist/keboola_mcp_server-${{ steps.get_version.outputs.version }}-py3-none-any.whl
+          name: keboola_mcp_server-${{ steps.get_package_version.outputs.version }}-py3-none-any.whl
+          path: dist/keboola_mcp_server-${{ steps.get_package_version.outputs.version }}-py3-none-any.whl
           if-no-files-found: error
           compression-level: 0  # wheels are ZIP archives
           retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,10 +88,7 @@ jobs:
     needs:
       - build
     runs-on: ubuntu-latest
-    if: >-
-      startsWith(github.ref, 'refs/tags/') && 
-      needs.build.outputs.is_semantic_tag == 'true' && 
-      needs.build.outputs.tag == 'v${{ needs.build.outputs.version }}'
+    if: startsWith(github.ref, 'refs/tags/') && needs.build.outputs.is_semantic_tag == 'true' && needs.build.outputs.tag == 'v${{ needs.build.outputs.version }}'
     steps:
       - name: Download wheel package
         uses: actions/download-artifact@v4


### PR DESCRIPTION
This adds the job to push `keboola_mcp_server` wheels package to `pypi.org`. I've tested it all up to the final step that actually does the push. That I plan to test in `master` branch after smoke testing the `development` branch and merging into `master` (including the changes in `ci.yaml` from this PR).

The `deploy_to_pypi` step is only run when the CI workflow runs from a GitHub "release" tag -- i.e. a tag such as `vX.Y.Z` and its `X.Y.Z` part is identical to the version in `pyproject.toml`.