### PR TITLE
Kab 991 refactor remove annotated

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "0.9.1"
+version = "0.9.2"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "keboola-mcp-server"
-version = "0.10.1"
+version = "0.10.2"
 description = "MCP server for interacting with Keboola Connection"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/keboola_mcp_server/client.py
+++ b/src/keboola_mcp_server/client.py
@@ -147,7 +147,6 @@ class KeboolaClient:
 
         Args:
             endpoint: API endpoint to call
-            data: Request payload
 
         Returns:
             API response as dictionary

--- a/src/keboola_mcp_server/client.py
+++ b/src/keboola_mcp_server/client.py
@@ -4,7 +4,7 @@ import logging
 import os
 import tempfile
 
-from typing import Annotated, Any, Dict, Mapping, Optional, cast, List
+from typing import Any, Dict, Mapping, Optional, cast, List
 
 
 import httpx
@@ -73,7 +73,7 @@ class KeboolaClient:
     async def get(
         self,
         endpoint: str,
-        params: Annotated[Optional[Dict[str, Any]], "Query parameters for the request"] = None,
+        params: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Make a GET request to Keboola Storage API.
 
@@ -96,10 +96,7 @@ class KeboolaClient:
     async def post(
         self,
         endpoint: str,
-        data: Annotated[
-            Optional[Dict[str, Any]],
-            "Request payload parameters as a dictionary.",
-        ],
+        data: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Make a POST request to Keboola Storage API.
 
@@ -122,9 +119,7 @@ class KeboolaClient:
     async def put(
         self,
         endpoint: str,
-        data: Annotated[
-            Optional[Dict[str, Any]], "Request payload parameters as a dictionary."
-        ] = None,
+        data: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Make a PUT request to Keboola Storage API.
 
@@ -147,9 +142,6 @@ class KeboolaClient:
     async def delete(
         self,
         endpoint: str,
-        data: Annotated[
-            Optional[Dict[str, Any]], "Request payload parameters as a dictionary."
-        ] = None,
     ) -> Dict[str, Any]:
         """Make a DELETE request to Keboola Storage API.
 

--- a/src/keboola_mcp_server/component_tools.py
+++ b/src/keboola_mcp_server/component_tools.py
@@ -38,9 +38,7 @@ def add_component_tools(mcp: FastMCP) -> None:
         retrieve_transformations_configurations,
         name=RETRIEVE_TRANSFORMATIONS_CONFIGURATIONS_TOOL_NAME,
     )
-    LOG.info(
-        f"Added tool {RETRIEVE_TRANSFORMATIONS_CONFIGURATIONS_TOOL_NAME} to the MCP server."
-    )
+    LOG.info(f"Added tool {RETRIEVE_TRANSFORMATIONS_CONFIGURATIONS_TOOL_NAME} to the MCP server.")
 
     mcp.add_tool(create_sql_transformation)
     LOG.info(f"Added tool {create_sql_transformation.__name__} to the MCP server.")


### PR DESCRIPTION
Removed `Annotated` from utility function parameters. Tool function parameters, visible to the bot, still use `Annotated` as required.